### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is a connector to allow Claude Desktop (or any MCP client) to fetch your saved articles from Pocket API.
 
+<a href="https://glama.ai/mcp/servers/1e2o9ooltu"><img width="380" height="200" src="https://glama.ai/mcp/servers/1e2o9ooltu/badge" alt="@kazuph/mcp-pocket MCP server" /></a>
+
 ## Prerequisites
 - Node.js (install via `brew install node`)
 - Claude Desktop (install from https://claude.ai/desktop)


### PR DESCRIPTION
This PR adds a badge for the @kazuph/mcp-pocket server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/1e2o9ooltu"><img width="380" height="200" src="https://glama.ai/mcp/servers/1e2o9ooltu/badge" alt="@kazuph/mcp-pocket MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.