### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # MCP Pocket
+[![smithery badge](https://smithery.ai/badge/@kazuph/mcp-pocket)](https://smithery.ai/server/@kazuph/mcp-pocket)
 
 This is a connector to allow Claude Desktop (or any MCP client) to fetch your saved articles from Pocket API.
 


### PR DESCRIPTION
This PR makes a change to the README.

1. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/@kazuph/mcp-pocket

Let me know if any tweaks have to be made!